### PR TITLE
Added 'period' argument for ForagaxSquareWaveBiome-v11 

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.12.0"
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "0.12.0"
           args: "format --check --diff"

--- a/src/foragax/registry.py
+++ b/src/foragax/registry.py
@@ -186,6 +186,7 @@ def make(
     aperture_size: Optional[Union[Tuple[int, int], int]] = (5, 5),
     reward_delay: int = 0,
     random_shift_max_steps: int = 0,
+    period: int | None = None, 
     **kwargs: Any,
 ) -> ForagaxEnv:
     """Create a Foragax environment.
@@ -196,8 +197,8 @@ def make(
         aperture_size: The size of the agent's observation aperture. If -1, full world observation.
             If None, the default for the environment is used.
         reward_delay: Number of steps required to digest food items.
+        period: The periodic cycle when the task switches in 'ForagaxSquareWaveTwoBiome-v11'. 
         **kwargs: Additional keyword arguments to pass to the ForagaxEnv constructor.
-
     Returns:
         A Foragax environment instance.
     """
@@ -227,7 +228,7 @@ def make(
     if env_id == "ForagaxSquareWaveTwoBiome-v11":
         biome1_oyster, biome1_chanterelle, biome2_oyster, biome2_chanterelle = (
             create_shift_square_wave_biome_objects(
-                period=500000,
+                period=500000 if period is None else period,
                 amplitude_big=9.0,
                 amplitude_small=3.0,
                 base_oyster_reward=-5.0,

--- a/src/foragax/registry.py
+++ b/src/foragax/registry.py
@@ -186,7 +186,7 @@ def make(
     aperture_size: Optional[Union[Tuple[int, int], int]] = (5, 5),
     reward_delay: int = 0,
     random_shift_max_steps: int = 0,
-    period: int | None = None, 
+    period: Optional[int] = None,
     **kwargs: Any,
 ) -> ForagaxEnv:
     """Create a Foragax environment.
@@ -197,7 +197,7 @@ def make(
         aperture_size: The size of the agent's observation aperture. If -1, full world observation.
             If None, the default for the environment is used.
         reward_delay: Number of steps required to digest food items.
-        period: The periodic cycle when the task switches in 'ForagaxSquareWaveTwoBiome-v11'. 
+        period: The periodic cycle when the task switches in 'ForagaxSquareWaveTwoBiome-v11'.
         **kwargs: Additional keyword arguments to pass to the ForagaxEnv constructor.
     Returns:
         A Foragax environment instance.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,6 +14,11 @@ def test_make_square_wave_two_biome_v11():
     assert env.name == "ForagaxSquareWaveTwoBiome-v11"
     assert env.size == (24, 15)
     assert env.deterministic_spawn
+    assert env.objects[1].period == 500000
+
+    # custom period test
+    env = make("ForagaxSquareWaveTwoBiome-v11", period=250)
+    assert env.objects[1].period == 250
 
 
 def test_make_two_biome_large_v1():


### PR DESCRIPTION
Also added tests to ensure period is saved in the env object. 

Fixed ruff version to ver 0.12.0 to match pre-commit hooks because ruff-action was resolving to latest since pyproject.toml doesn't pin a version, so CI was silently picking up new default-enabled lint rules and flagging pre-existing issues across the codebase.

