### PR TITLE
fix: exclude walls from reward-to-color render overlay

### DIFF
--- a/src/foragax/env.py
+++ b/src/foragax/env.py
@@ -2071,8 +2071,11 @@ class ForagaxEnv(environment.Environment):
 
             reward = self._apply_centering(reward, obj_id, global_mean)
 
-            # Only show reward for objects that are fully present (no timer)
-            mask = (obj_id > 0) & (timer == 0)
+            # Only show reward for objects that are fully present (no timer).
+            # Ignore walls (blocking objects): they carry reward = -inf as an
+            # internal sentinel, not a real reward to render/display.
+            is_not_wall = ~self.object_blocking[obj_id.astype(jnp.int32)]
+            mask = (obj_id > 0) & (timer == 0) & is_not_wall
             return jnp.where(mask, reward, 0.0)
 
         reward_grid = jax.vmap(jax.vmap(compute_reward))(


### PR DESCRIPTION
## Summary
- Walls carry `reward = -jnp.inf` as an internal blocking sentinel (see `WALL` in `objects.py`), not a real reward value.
- `_compute_reward_grid()` (used only by `render()`'s `*_reward` modes) was missing the `is_not_wall` mask that the other reward-grid computations in `env.py` already apply (e.g. in `step()`), so wall cells kept a nonzero (`-inf`, clamped to -1) reward value.
- `reward_to_color()` maps that clamped value to a magenta "negative reward" color, and `apply_reward_overlay()` draws it as a dot on top of the wall's tile — so walls rendered with a magenta dot instead of showing as their plain black base tile color.
- Fix: mask wall cells to `reward = 0.0` in `_compute_reward_grid()`, consistent with the `is_not_wall` pattern already used elsewhere. A reward of exactly 0 is below the overlay's `abs(reward) > 1e-5` threshold, so no dot is drawn and the wall shows its normal black base color.

## Test plan
- [x] Rendered `ForagaxBig-v5` in `world_reward` mode before/after the fix and visually compared: walls show a magenta dot before, plain black after; all other cells (food, empty, aperture tint) are pixel-identical.
- [ ] No existing test suite covers rendering/reward-grid output; consider adding one if desired.